### PR TITLE
Implement Task 1 & 2: Applications API + scheduled NBN ordering (tests included)

### DIFF
--- a/SUBMISSION_NOTES.md
+++ b/SUBMISSION_NOTES.md
@@ -1,0 +1,84 @@
+# Submission Notes
+
+## Overview
+
+This submission implements the two tasks from the assessment brief using conventional Laravel patterns (FormRequests, Resources, Commands, Jobs, and the Scheduler). All behaviour is verified by automated tests runnable via `php artisan test` using the provided in-memory SQLite configuration.
+
+## How to run
+
+-   `composer install`
+-   `php artisan test`
+
+## Task 1 - Expose a new API endpoint to list all applications
+
+### Key decisions (why)
+
+-   Reused the existing `auth:sanctum` pattern (same as `/api/user`) to keep auth out of scope and avoid introducing new auth behaviour.
+-   Used a FormRequest to validate `plan_type` to keep the API contract strict and predictable.
+-   Used an API Resource to ensure ONLY the required fields are returned and to keep formatting/composition logic out of the controller.
+-   Used eager loading + pagination for scalability and to avoid N+1 queries.
+
+### Implementation (what)
+
+-   Route: `GET /api/applications` (authenticated).
+-   Optional query: `plan_type` (`nbn|opticomm|mobile`).
+-   Ordering: oldest first (`created_at` ascending).
+-   Response item fields:
+    -   `application_id`
+    -   `customer_full_name`
+    -   `address` (composed from `address_1`, optional `address_2`, `city` + `postcode`; state returned separately)
+    -   `plan_type`
+    -   `plan_name`
+    -   `state`
+    -   `plan_monthly_cost` (cents -> dollar string with 2dp)
+    -   `order_id` only when status is `complete`
+
+### Evidence
+
+-   Code: `routes/api.php`, `app/Http/Controllers/Api/ApplicationController.php`, `app/Http/Requests/ApplicationIndexRequest.php`, `app/Http/Resources/ApplicationResource.php`, `app/Models/Application.php`
+-   Tests: `tests/Feature/ApplicationsIndexTest.php` (empty response, pagination/shape, ordering, filtering, cents formatting, conditional `order_id`, validation, auth behaviour)
+-   Auth note: this repo’s `app/Http/Middleware/Authenticate.php` aborts unauthenticated API requests with `403`. The guest test tolerates `401` or `403` to stay stable across common Sanctum/Laravel defaults.
+
+## Task 2 - Automate the ordering of all nbn applications
+
+### Key decisions (why)
+
+-   Used scheduler + command + queued job to match Laravel conventions and keep periodic work out of web requests.
+-   Dispatcher uses `chunkById()` and selects only `id` to keep processing scalable.
+-   Job re-checks eligibility (status still `order`, plan still `nbn`) to reduce race-condition risk.
+-   A single failure path (`order failed`) for failure responses, missing config, or exceptions keeps state transitions easy to reason about.
+
+### Implementation (what)
+
+-   Scheduler: runs `nbn:dispatch-orders` every five minutes and uses `withoutOverlapping()`.
+-   Dispatcher command: finds applications where `status=order` and `plan.type=nbn`, dispatching one job per application.
+-   Job:
+    -   Posts to `NBN_B2B_ENDPOINT` (exposed as `services.nbn.endpoint`) with payload: `address_1`, `address_2`, `city`, `state`, `postcode`, `plan_name` (plan name value).
+    -   Success (per provided stub contract): response is HTTP 200 + JSON `status` = `Successful` + non-empty `id` → persist `order_id` and set status to `complete`.
+    -   Failure/exception/missing endpoint/missing plan name → clear `order_id` and set status to `order failed` (enum value includes a space).
+
+### Evidence
+
+-   Code: `app/Console/Kernel.php`, `app/Console/Commands/DispatchNbnOrders.php`, `app/Jobs/OrderNbnApplication.php`, `config/services.php`
+-   Stubs: `tests/stubs/nbn-successful-response.json`, `tests/stubs/nbn-fail-response.json`
+-   Tests:
+    -   `tests/Feature/DispatchNbnOrdersCommandTest.php` (only eligible apps dispatch jobs)
+    -   `tests/Feature/OrderNbnApplicationTest.php` (success path, failure response, exception, non-nbn, non-order, missing endpoint, missing plan name; asserts payload and `Http::assertSentCount(1)`)
+
+## Notes (non-task changes)
+
+These changes were made purely to keep `php artisan test` runnable in this repo, and do not affect the task logic:
+
+-   CORS middleware: replaced missing `Fruitcake\\Cors\\HandleCors` reference with Laravel’s built-in `Illuminate\\Http\\Middleware\\HandleCors` (`app/Http/Kernel.php`).
+-   PHP deprecation notice: adjusted SSL CA PDO constant usage (`config/database.php`) to keep tests clean on newer PHP versions; no impact on the in-memory SQLite test suite.
+-   HTTP client dependency: added `guzzlehttp/guzzle` because Laravel’s HTTP client (`Http::post()` / `Http::fake()`) requires it; this repo did not include it by default. The assessor brief allows adding packages if justified. This keeps the implementation aligned with the requirement to use `Http::post()` and prevents real network calls in tests.
+
+## If I had more time
+
+-   Add stronger idempotency guarantees around ordering (e.g. unique jobs or external idempotency keys) and structured logging.
+-   Add retry/backoff + timeouts around the B2B call once API/SLA expectations are known.
+-   Add a few pagination edge-case tests (e.g. multiple pages) if the UI requirements were clearer.
+
+## Submission packaging
+
+-   Per the brief: submit a zip/tarball excluding `vendor/` while preserving git history.

--- a/app/Console/Commands/DispatchNbnOrders.php
+++ b/app/Console/Commands/DispatchNbnOrders.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\ApplicationStatus;
+use App\Jobs\OrderNbnApplication;
+use App\Models\Application;
+use Illuminate\Console\Command;
+
+class DispatchNbnOrders extends Command
+{
+    protected $signature = 'nbn:dispatch-orders';
+
+    protected $description = 'Dispatch queue jobs for NBN applications ready to order.';
+
+    public function handle(): int
+    {
+        Application::query()
+            ->where('status', ApplicationStatus::Order)
+            ->whereHas('plan', fn ($planQuery) => $planQuery->where('type', 'nbn'))
+            ->orderBy('id')
+            ->select('id')
+            ->chunkById(500, function ($applications) {
+                foreach ($applications as $application) {
+                    OrderNbnApplication::dispatch($application->id);
+                }
+            });
+
+        return self::SUCCESS;
+    }
+}
+

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,7 +15,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('nbn:dispatch-orders')->everyFiveMinutes()->withoutOverlapping();
     }
 
     /**

--- a/app/Http/Controllers/Api/ApplicationController.php
+++ b/app/Http/Controllers/Api/ApplicationController.php
@@ -6,10 +6,11 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\ApplicationIndexRequest;
 use App\Http\Resources\ApplicationResource;
 use App\Models\Application;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class ApplicationController extends Controller
 {
-    public function index(ApplicationIndexRequest $request)
+    public function index(ApplicationIndexRequest $request): AnonymousResourceCollection
     {
         $query = Application::query()
             ->with(['customer', 'plan'])

--- a/app/Http/Controllers/Api/ApplicationController.php
+++ b/app/Http/Controllers/Api/ApplicationController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ApplicationIndexRequest;
+use App\Http\Resources\ApplicationResource;
+use App\Models\Application;
+
+class ApplicationController extends Controller
+{
+    public function index(ApplicationIndexRequest $request)
+    {
+        $query = Application::query()
+            ->with(['customer', 'plan'])
+            ->orderBy('created_at');
+
+        $planType = $request->validated('plan_type');
+
+        if ($planType !== null) {
+            $query->whereHas('plan', function ($planQuery) use ($planType) {
+                $planQuery->where('type', $planType);
+            });
+        }
+
+        return ApplicationResource::collection($query->paginate());
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,

--- a/app/Http/Requests/ApplicationIndexRequest.php
+++ b/app/Http/Requests/ApplicationIndexRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ApplicationIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'plan_type' => ['nullable', Rule::in(['nbn', 'opticomm', 'mobile'])],
+        ];
+    }
+}
+

--- a/app/Http/Requests/ApplicationIndexRequest.php
+++ b/app/Http/Requests/ApplicationIndexRequest.php
@@ -15,8 +15,7 @@ class ApplicationIndexRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'plan_type' => ['nullable', Rule::in(['nbn', 'opticomm', 'mobile'])],
+            'plan_type' => ['nullable', 'string', Rule::in(['nbn', 'opticomm', 'mobile'])],
         ];
     }
 }
-

--- a/app/Http/Resources/ApplicationResource.php
+++ b/app/Http/Resources/ApplicationResource.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Enums\ApplicationStatus;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ApplicationResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $customerFullName = trim(implode(' ', array_filter([
+            $this->customer?->first_name,
+            $this->customer?->last_name,
+        ])));
+
+        $addressParts = array_values(array_filter([
+            $this->address_1,
+            $this->address_2,
+            trim($this->city . ' ' . $this->postcode),
+        ], fn ($part) => $part !== null && $part !== ''));
+
+        $monthlyCostCents = (int) ($this->plan?->monthly_cost ?? 0);
+
+        return [
+            'application_id' => $this->id,
+            'customer_full_name' => $customerFullName,
+            'address' => implode(', ', $addressParts),
+            'plan_type' => $this->plan?->type,
+            'plan_name' => $this->plan?->name,
+            'state' => $this->state,
+            'plan_monthly_cost' => $this->formatMonthlyCost($monthlyCostCents),
+            $this->mergeWhen($this->status === ApplicationStatus::Complete, [
+                'order_id' => $this->order_id,
+            ]),
+        ];
+    }
+
+    private function formatMonthlyCost(int $cents): string
+    {
+        $sign = $cents < 0 ? '-' : '';
+        $cents = abs($cents);
+
+        return sprintf('%s%d.%02d', $sign, intdiv($cents, 100), $cents % 100);
+    }
+}

--- a/app/Jobs/OrderNbnApplication.php
+++ b/app/Jobs/OrderNbnApplication.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\ApplicationStatus;
+use App\Models\Application;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+class OrderNbnApplication implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $applicationId)
+    {
+    }
+
+    public function handle(): void
+    {
+        $application = Application::query()->with('plan')->find($this->applicationId);
+
+        if ($application === null) {
+            return;
+        }
+
+        if ($application->status !== ApplicationStatus::Order) {
+            return;
+        }
+
+        if ($application->plan?->type !== 'nbn') {
+            return;
+        }
+
+        $endpoint = config('services.nbn.endpoint');
+
+        if (! is_string($endpoint) || $endpoint === '') {
+            $this->markOrderFailed($application);
+            return;
+        }
+
+        $planName = $application->plan?->name;
+
+        if (! is_string($planName) || $planName === '') {
+            $this->markOrderFailed($application);
+            return;
+        }
+
+        $payload = [
+            'address_1' => $application->address_1,
+            'address_2' => $application->address_2,
+            'city' => $application->city,
+            'state' => $application->state,
+            'postcode' => $application->postcode,
+            'plan_name' => $planName,
+        ];
+
+        try {
+            $response = Http::post($endpoint, $payload);
+
+            $responseStatus = $response->json('status');
+            $orderId = $response->json('id');
+
+            if ($response->successful() && $responseStatus === 'Successful' && is_string($orderId) && $orderId !== '') {
+                $application->order_id = $orderId;
+                $application->status = ApplicationStatus::Complete;
+                $application->save();
+
+                return;
+            }
+        } catch (Throwable) {
+            // handled below
+        }
+
+        $this->markOrderFailed($application);
+    }
+
+    private function markOrderFailed(Application $application): void
+    {
+        $application->order_id = null;
+        $application->status = ApplicationStatus::OrderFailed;
+        $application->save();
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\ApplicationStatus;
 use App\Events\ApplicationCreated;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Application extends Model
@@ -18,4 +19,14 @@ class Application extends Model
     protected $dispatchesEvents = [
         'created' => ApplicationCreated::class,
     ];
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+
+    public function plan(): BelongsTo
+    {
+        return $this->belongsTo(Plan::class);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "guzzlehttp/guzzle": "^7.5",
         "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd37d5784d23f10c6b510d6b40e4aba5",
+    "content-hash": "f55942ccebd22e1e911d3d33d1b0c7e8",
     "packages": [
         {
             "name": "brick/math",
@@ -564,6 +564,331 @@
                 }
             ],
             "time": "2023-02-25T20:23:15+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-23T22:36:01+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-22T14:34:08+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "21dc724a0583619cd1652f673303492272778051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
+                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-23T21:21:41+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -2046,6 +2371,166 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "3.0.0",
             "source": {
@@ -2221,6 +2706,50 @@
                 "source": "https://github.com/bobthecow/psysh/tree/v0.11.15"
             },
             "time": "2023-04-07T21:57:09+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "ramsey/collection",
@@ -7797,12 +8326,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/config/database.php
+++ b/config/database.php
@@ -59,7 +59,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (class_exists(\Pdo\Mysql::class) ?\Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/config/services.php
+++ b/config/services.php
@@ -30,4 +30,8 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'nbn' => [
+        'endpoint' => env('NBN_B2B_ENDPOINT'),
+    ],
+
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\ApplicationController;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,3 +18,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::middleware('auth:sanctum')->get('/applications', [ApplicationController::class, 'index']);

--- a/tests/Feature/ApplicationsIndexTest.php
+++ b/tests/Feature/ApplicationsIndexTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ApplicationStatus;
+use App\Models\Application;
+use App\Models\Customer;
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ApplicationsIndexTest extends TestCase
+{
+    public function test_guest_cannot_list_applications(): void
+    {
+        $this->getJson('/api/applications')->assertUnauthorized();
+    }
+
+    public function test_it_returns_paginated_oldest_first_applications_with_expected_shape(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+
+        $planNbn = Plan::factory()->create([
+            'type' => 'nbn',
+            'name' => 'NBN 50',
+            'monthly_cost' => 1234,
+        ]);
+        $customerAlice = Customer::factory()->create([
+            'first_name' => 'Alice',
+            'last_name' => 'Smith',
+        ]);
+        $oldestComplete = Application::factory()->create([
+            'status' => ApplicationStatus::Complete,
+            'customer_id' => $customerAlice->id,
+            'plan_id' => $planNbn->id,
+            'address_1' => '1 Test St',
+            'address_2' => 'Unit 2',
+            'city' => 'Sydney',
+            'state' => 'NSW',
+            'postcode' => '2000',
+            'order_id' => 'ORDER-123',
+            'created_at' => Carbon::now()->subDays(2),
+        ]);
+
+        $planMobile = Plan::factory()->create([
+            'type' => 'mobile',
+            'name' => 'Mobile 20',
+            'monthly_cost' => 2500,
+        ]);
+        $customerBob = Customer::factory()->create([
+            'first_name' => 'Bob',
+            'last_name' => 'Jones',
+        ]);
+        $newerOrder = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'customer_id' => $customerBob->id,
+            'plan_id' => $planMobile->id,
+            'address_1' => '2 Example Rd',
+            'address_2' => null,
+            'city' => 'Melbourne',
+            'state' => 'VIC',
+            'postcode' => '3000',
+            'order_id' => 'ORDER-SHOULD-NOT-SHOW',
+            'created_at' => Carbon::now()->subDay(),
+        ]);
+
+        $response = $this->getJson('/api/applications');
+
+        $response->assertOk()->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'application_id',
+                    'customer_full_name',
+                    'address',
+                    'plan_type',
+                    'plan_name',
+                    'state',
+                    'plan_monthly_cost',
+                ],
+            ],
+            'links' => ['first', 'last', 'prev', 'next'],
+            'meta' => ['current_page', 'from', 'last_page', 'path', 'per_page', 'to', 'total'],
+        ]);
+
+        $response->assertJsonPath('meta.total', 2);
+
+        $data = $response->json('data');
+        $this->assertCount(2, $data);
+
+        $this->assertSame($oldestComplete->id, $data[0]['application_id']);
+        $this->assertSame($newerOrder->id, $data[1]['application_id']);
+
+        $this->assertEqualsCanonicalizing([
+            'application_id',
+            'customer_full_name',
+            'address',
+            'plan_type',
+            'plan_name',
+            'state',
+            'plan_monthly_cost',
+            'order_id',
+        ], array_keys($data[0]));
+        $this->assertSame('Alice Smith', $data[0]['customer_full_name']);
+        $this->assertSame('1 Test St, Unit 2, Sydney 2000', $data[0]['address']);
+        $this->assertSame('nbn', $data[0]['plan_type']);
+        $this->assertSame('NBN 50', $data[0]['plan_name']);
+        $this->assertSame('NSW', $data[0]['state']);
+        $this->assertSame('12.34', $data[0]['plan_monthly_cost']);
+        $this->assertIsString($data[0]['plan_monthly_cost']);
+        $this->assertSame('ORDER-123', $data[0]['order_id']);
+
+        $this->assertEqualsCanonicalizing([
+            'application_id',
+            'customer_full_name',
+            'address',
+            'plan_type',
+            'plan_name',
+            'state',
+            'plan_monthly_cost',
+        ], array_keys($data[1]));
+        $this->assertSame('Bob Jones', $data[1]['customer_full_name']);
+        $this->assertSame('2 Example Rd, Melbourne 3000', $data[1]['address']);
+        $this->assertSame('mobile', $data[1]['plan_type']);
+        $this->assertSame('Mobile 20', $data[1]['plan_name']);
+        $this->assertSame('VIC', $data[1]['state']);
+        $this->assertSame('25.00', $data[1]['plan_monthly_cost']);
+        $this->assertIsString($data[1]['plan_monthly_cost']);
+        $this->assertArrayNotHasKey('order_id', $data[1]);
+    }
+
+    public function test_it_can_filter_by_each_plan_type(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+
+        $planNbn = Plan::factory()->create(['type' => 'nbn']);
+        $planOpticomm = Plan::factory()->create(['type' => 'opticomm']);
+        $planMobile = Plan::factory()->create(['type' => 'mobile']);
+
+        Application::factory()->create(['plan_id' => $planNbn->id]);
+        Application::factory()->create(['plan_id' => $planOpticomm->id]);
+        Application::factory()->create(['plan_id' => $planMobile->id]);
+
+        foreach (['nbn', 'opticomm', 'mobile'] as $planType) {
+            $response = $this->getJson("/api/applications?plan_type={$planType}");
+
+            $response->assertOk()->assertJsonPath('meta.total', 1);
+            $this->assertSame($planType, $response->json('data.0.plan_type'));
+        }
+    }
+}

--- a/tests/Feature/ApplicationsIndexTest.php
+++ b/tests/Feature/ApplicationsIndexTest.php
@@ -23,6 +23,22 @@ class ApplicationsIndexTest extends TestCase
         );
     }
 
+    public function test_it_returns_empty_paginated_response_when_no_applications_exist(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+
+        $response = $this->getJson('/api/applications');
+
+        $response->assertOk()
+            ->assertJsonCount(0, 'data')
+            ->assertJsonPath('meta.total', 0)
+            ->assertJsonStructure([
+                'data',
+                'links' => ['first', 'last', 'prev', 'next'],
+                'meta' => ['current_page', 'from', 'last_page', 'path', 'per_page', 'to', 'total'],
+            ]);
+    }
+
     public function test_it_returns_paginated_oldest_first_applications_with_expected_shape(): void
     {
         Sanctum::actingAs(User::factory()->create());

--- a/tests/Feature/ApplicationsIndexTest.php
+++ b/tests/Feature/ApplicationsIndexTest.php
@@ -15,7 +15,12 @@ class ApplicationsIndexTest extends TestCase
 {
     public function test_guest_cannot_list_applications(): void
     {
-        $this->getJson('/api/applications')->assertUnauthorized();
+        $response = $this->getJson('/api/applications');
+
+        $this->assertTrue(
+            in_array($response->status(), [401, 403], true),
+            "Expected 401 or 403, got {$response->status()}."
+        );
     }
 
     public function test_it_returns_paginated_oldest_first_applications_with_expected_shape(): void
@@ -146,7 +151,20 @@ class ApplicationsIndexTest extends TestCase
             $response = $this->getJson("/api/applications?plan_type={$planType}");
 
             $response->assertOk()->assertJsonPath('meta.total', 1);
-            $this->assertSame($planType, $response->json('data.0.plan_type'));
+            $response->assertJsonCount(1, 'data');
+
+            foreach ($response->json('data') as $application) {
+                $this->assertSame($planType, $application['plan_type']);
+            }
         }
+    }
+
+    public function test_it_validates_plan_type_filter(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+
+        $this->getJson('/api/applications?plan_type=foo')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['plan_type']);
     }
 }

--- a/tests/Feature/DispatchNbnOrdersCommandTest.php
+++ b/tests/Feature/DispatchNbnOrdersCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ApplicationStatus;
+use App\Jobs\OrderNbnApplication;
+use App\Models\Application;
+use App\Models\Plan;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class DispatchNbnOrdersCommandTest extends TestCase
+{
+    public function test_it_dispatches_jobs_for_order_status_nbn_applications_only(): void
+    {
+        Queue::fake();
+
+        $planNbn = Plan::factory()->create(['type' => 'nbn']);
+        $planMobile = Plan::factory()->create(['type' => 'mobile']);
+
+        $eligibleOne = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $planNbn->id,
+        ]);
+        $eligibleTwo = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $planNbn->id,
+        ]);
+
+        $ineligibleWrongStatus = Application::factory()->create([
+            'status' => ApplicationStatus::Prelim,
+            'plan_id' => $planNbn->id,
+        ]);
+        $ineligibleWrongPlanType = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $planMobile->id,
+        ]);
+
+        $this->artisan('nbn:dispatch-orders')->assertExitCode(0);
+
+        Queue::assertPushed(OrderNbnApplication::class, 2);
+        Queue::assertPushed(OrderNbnApplication::class, fn (OrderNbnApplication $job) => $job->applicationId === $eligibleOne->id);
+        Queue::assertPushed(OrderNbnApplication::class, fn (OrderNbnApplication $job) => $job->applicationId === $eligibleTwo->id);
+
+        Queue::assertNotPushed(OrderNbnApplication::class, fn (OrderNbnApplication $job) => $job->applicationId === $ineligibleWrongStatus->id);
+        Queue::assertNotPushed(OrderNbnApplication::class, fn (OrderNbnApplication $job) => $job->applicationId === $ineligibleWrongPlanType->id);
+    }
+}
+

--- a/tests/Feature/OrderNbnApplicationTest.php
+++ b/tests/Feature/OrderNbnApplicationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ApplicationStatus;
+use App\Jobs\OrderNbnApplication;
+use App\Models\Application;
+use App\Models\Plan;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class OrderNbnApplicationTest extends TestCase
+{
+    public function test_it_orders_an_nbn_application_and_marks_complete_on_success(): void
+    {
+        $endpoint = 'https://nbn.example/orders';
+        config(['services.nbn.endpoint' => $endpoint]);
+
+        $payload = json_decode(file_get_contents(base_path('tests/stubs/nbn-successful-response.json')), true);
+
+        Http::fake([
+            $endpoint => Http::response($payload, 200),
+        ]);
+
+        $plan = Plan::factory()->create([
+            'type' => 'nbn',
+            'name' => 'NBN 50',
+        ]);
+        $application = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $plan->id,
+            'address_1' => '1 Test St',
+            'address_2' => null,
+            'city' => 'Sydney',
+            'state' => 'NSW',
+            'postcode' => '2000',
+        ]);
+
+        OrderNbnApplication::dispatchSync($application->id);
+
+        $application->refresh();
+        $this->assertSame(ApplicationStatus::Complete, $application->status);
+        $this->assertSame($payload['id'], $application->order_id);
+
+        Http::assertSentCount(1);
+        Http::assertSent(function (Request $request) use ($endpoint, $application, $plan) {
+            if ($request->url() !== $endpoint || $request->method() !== 'POST') {
+                return false;
+            }
+
+            $data = $request->data();
+
+            return ($data['address_1'] ?? null) === $application->address_1
+                && array_key_exists('address_2', $data) && ($data['address_2'] ?? null) === $application->address_2
+                && ($data['city'] ?? null) === $application->city
+                && ($data['state'] ?? null) === $application->state
+                && ($data['postcode'] ?? null) === $application->postcode
+                && ($data['plan_name'] ?? null) === $plan->name;
+        });
+    }
+
+    public function test_it_marks_order_failed_on_failure_response(): void
+    {
+        $endpoint = 'https://nbn.example/orders';
+        config(['services.nbn.endpoint' => $endpoint]);
+
+        $payload = json_decode(file_get_contents(base_path('tests/stubs/nbn-fail-response.json')), true);
+
+        Http::fake([
+            $endpoint => Http::response($payload, 200),
+        ]);
+
+        $plan = Plan::factory()->create(['type' => 'nbn']);
+        $application = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $plan->id,
+        ]);
+
+        OrderNbnApplication::dispatchSync($application->id);
+
+        $application->refresh();
+        $this->assertSame(ApplicationStatus::OrderFailed, $application->status);
+        $this->assertNull($application->order_id);
+    }
+
+    public function test_it_marks_order_failed_when_the_http_client_throws(): void
+    {
+        $endpoint = 'https://nbn.example/orders';
+        config(['services.nbn.endpoint' => $endpoint]);
+
+        Http::fake(function () {
+            throw new \Exception('boom');
+        });
+
+        $plan = Plan::factory()->create(['type' => 'nbn']);
+        $application = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $plan->id,
+        ]);
+
+        OrderNbnApplication::dispatchSync($application->id);
+
+        $application->refresh();
+        $this->assertSame(ApplicationStatus::OrderFailed, $application->status);
+        $this->assertNull($application->order_id);
+    }
+
+    public function test_it_does_not_process_non_nbn_or_non_order_applications(): void
+    {
+        Http::fake();
+
+        $plan = Plan::factory()->create(['type' => 'mobile']);
+        $application = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $plan->id,
+        ]);
+
+        OrderNbnApplication::dispatchSync($application->id);
+
+        $application->refresh();
+        $this->assertSame(ApplicationStatus::Order, $application->status);
+        $this->assertNull($application->order_id);
+        Http::assertNothingSent();
+    }
+
+    public function test_it_does_not_process_when_application_is_not_in_order_status(): void
+    {
+        Http::fake();
+
+        $plan = Plan::factory()->create(['type' => 'nbn']);
+        $application = Application::factory()->create([
+            'status' => ApplicationStatus::Prelim,
+            'plan_id' => $plan->id,
+        ]);
+
+        OrderNbnApplication::dispatchSync($application->id);
+
+        $application->refresh();
+        $this->assertSame(ApplicationStatus::Prelim, $application->status);
+        $this->assertNull($application->order_id);
+        Http::assertNothingSent();
+    }
+
+    public function test_it_marks_order_failed_when_endpoint_is_missing(): void
+    {
+        config(['services.nbn.endpoint' => null]);
+        Http::fake();
+
+        $plan = Plan::factory()->create(['type' => 'nbn']);
+        $application = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $plan->id,
+        ]);
+
+        OrderNbnApplication::dispatchSync($application->id);
+
+        $application->refresh();
+        $this->assertSame(ApplicationStatus::OrderFailed, $application->status);
+        $this->assertNull($application->order_id);
+        Http::assertNothingSent();
+    }
+}

--- a/tests/Feature/OrderNbnApplicationTest.php
+++ b/tests/Feature/OrderNbnApplicationTest.php
@@ -160,4 +160,28 @@ class OrderNbnApplicationTest extends TestCase
         $this->assertNull($application->order_id);
         Http::assertNothingSent();
     }
+
+    public function test_it_marks_order_failed_when_plan_name_is_missing(): void
+    {
+        $endpoint = 'https://nbn.example/orders';
+        config(['services.nbn.endpoint' => $endpoint]);
+        Http::fake();
+
+        $plan = Plan::factory()->create([
+            'type' => 'nbn',
+            'name' => '',
+        ]);
+        $application = Application::factory()->create([
+            'status' => ApplicationStatus::Order,
+            'plan_id' => $plan->id,
+            'order_id' => 'ORDER-SHOULD-BE-CLEARED',
+        ]);
+
+        OrderNbnApplication::dispatchSync($application->id);
+
+        $application->refresh();
+        $this->assertSame(ApplicationStatus::OrderFailed, $application->status);
+        $this->assertNull($application->order_id);
+        Http::assertNothingSent();
+    }
 }


### PR DESCRIPTION
## Summary
Implements both tasks from the Laravel tech test using standard Laravel conventions (FormRequests, API Resources, Commands, Jobs, Scheduler) with full test coverage.

## Task 1 — List Applications API
- Adds authenticated `GET /api/applications` (Sanctum).
- Supports optional `plan_type` filter (`nbn|opticomm|mobile`).
- Returns paginated results ordered oldest-first (`created_at` ascending).
- Response is shaped via an API Resource to return only the required fields; `order_id` is included only when status is `complete`.

## Task 2 — Order NBN applications (scheduled + queued)
- Schedules `nbn:dispatch-orders` every 5 minutes with `withoutOverlapping()`.
- Dispatcher selects eligible applications (`status=order` + `plan.type=nbn`) and dispatches one queue job per application.
- Job calls `Http::post()` to `NBN_B2B_ENDPOINT` (via `services.nbn.endpoint`) using the provided stub contract:
  - Success: store `order_id` and set status to `complete`.
  - Failure/exception: set status to `order failed` (and clear `order_id`).
- Tests use `Http::fake()` and the provided stub JSON files (no real HTTP requests).

## Tests
- Run: `php artisan test`
- Covers: API contract (shape/pagination/order/filter/validation), dispatcher eligibility, job success/failure/exception + payload assertions.

## Notes (non-task fixes to keep tests runnable)
- Updated CORS middleware reference to Laravel’s built-in `Illuminate\Http\Middleware\HandleCors`.
- Adjusted PDO SSL CA constant usage to avoid deprecation notices on newer PHP versions (no impact on SQLite tests).
- Added `guzzlehttp/guzzle` because Laravel’s HTTP client (`Http::post()` / `Http::fake()`) requires it; keeps the implementation aligned with the brief and prevents real network calls in tests.

## Test Run (local)
`php artisan test` — Tests: 13 passed (111 assertions)

<img width="560" height="305" alt="test-run-local-results" src="https://github.com/user-attachments/assets/641670f4-d71f-4962-a9eb-e27be625f3fc" />